### PR TITLE
Fix Android build and update to NDK r12b.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: android
+language: scala
+scala: 2.11.7
 sudo: false
 
 addons:
@@ -10,16 +11,6 @@ addons:
       - clang-3.5
       - p7zip-full
 
-android:
-  components:
-    #- android-23
-    #- platform-tools
-    #- extra-android-support
-    #- extra-android-m2repository
-    #- sys-img-aarch64-android-23
-    #- sys-img-armeabi-v7a-android-19
-    #- sys-img-x86-android-23
-
 cache:
   directories:
     - $HOME/cache
@@ -30,11 +21,11 @@ env:
     - TEST_GOAL=coverage TOXCORE=toktok/c-toxcore
     - TEST_GOAL=performance TOXCORE=irungentoo/toxcore
     # Production builds after test builds so only tested artifacts are uploaded.
-    #- TARGET=x86_64-linux
-    #- TARGET=aarch64-linux-android
-    #- TARGET=arm-linux-androideabi
-    #- TARGET=i686-linux-android
-    #- TARGET=x86_64-linux-android
+    - TARGET=x86_64-linux
+    - TARGET=aarch64-linux-android
+    - TARGET=arm-linux-androideabi
+    - TARGET=i686-linux-android
+    - TARGET=x86_64-linux-android
 
 matrix:
   fast_finish: true
@@ -42,14 +33,12 @@ matrix:
 install:
   # Move files from cache directory.
   - make cache
-  # Set-up step.
-  - export NDK_HOME=$HOME/android-ndk
-  - make setup
 
 script:
-  # Build/install/test step.
+  - export NDK_HOME=$HOME/android-ndk
+  # Setup/build/install/test steps, all together.
   - mkdir -p /tmp/android-travis
-  - make install
+  - make all
 
 before_cache:
   - make upload

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // General settings.
 organization  := "org.toktok"
 name          := "tox4j-c"
-version       := "0.1.0"
+version       := "0.1.0-SNAPSHOT"
 scalaVersion  := "2.11.7"
 
 bintrayVcsUrl := Some("https://github.com/TokTok/jvm-toxcore-c")

--- a/buildscripts/01_ndk
+++ b/buildscripts/01_ndk
@@ -52,7 +52,7 @@ my %NDK_FILES = (
 );
 
 
-my $NDK_DIR = "android-ndk-r11b";
+my $NDK_DIR = "android-ndk-r12b";
 my $NDK_PACKAGE = "$NDK_DIR-$^O-x86_64.zip";
 
 if ($C->HOST ne $C->TARGET) {
@@ -79,8 +79,7 @@ if ($C->HOST ne $C->TARGET) {
    };
 
    if ($@ =~ /No such file or directory/) {
-      # 7z didn't exist, so just run the self-extracting archive.
-      chmod 0700, $NDK_PACKAGE;
+      # 7z didn't exist, so just unzip the whole archive.
       @lines = must_popen "unzip", $NDK_PACKAGE;
    }
 

--- a/buildscripts/02_toolchain
+++ b/buildscripts/02_toolchain
@@ -17,25 +17,18 @@ my $C = require C;
 ##############################################################################
 
 
-my %STL = (
-   'arm-linux-androideabi' => 'gnustl',
-   'aarch64-linux-android' => 'gnustl',
-   'i686-linux-android'    => 'gnustl',
-   'x86_64-linux-android'  => 'gnustl',
-);
-
-my %TOOLCHAIN = (
-   'arm-linux-androideabi' => 'arm-linux-androideabi',
-   'aarch64-linux-android' => 'aarch64-linux-android',
+my %ARCH = (
+   'arm-linux-androideabi' => 'arm',
+   'aarch64-linux-android' => 'arm64',
    'i686-linux-android'    => 'x86',
    'x86_64-linux-android'  => 'x86_64',
 );
 
-my %PLATFORM = (
-   'arm-linux-androideabi' => 'android-9',
-   'aarch64-linux-android' => 'android-21',
-   'i686-linux-android'    => 'android-9',
-   'x86_64-linux-android'  => 'android-21',
+my %API = (
+   'arm-linux-androideabi' => 9,
+   'aarch64-linux-android' => 21,
+   'i686-linux-android'    => 9,
+   'x86_64-linux-android'  => 21,
 );
 
 
@@ -49,12 +42,11 @@ if ($C->HOST ne $C->TARGET) {
 
    # Install a standalone Android NDK toolchain.
    must_system (
-      $C->NDK_HOME . "/build/tools/make-standalone-toolchain.sh",
-      "--stl=$STL{$C->TARGET}",
-      "--ndk-dir=" . $C->NDK_HOME,
-      "--toolchain=$TOOLCHAIN{$C->TARGET}-clang",
-      "--install-dir=$toolchain",
-      "--platform=$PLATFORM{$C->TARGET}",
+      $C->NDK_HOME . "/build/tools/make_standalone_toolchain.py",
+      "--arch", $ARCH{$C->TARGET},
+      "--install-dir", $toolchain,
+      "--api", $API{$C->TARGET},
+      "--force",
    );
 
    my $cached_sysroot = $C->CACHE_DIR . "/" . $C->TARGET;

--- a/buildscripts/05_android
+++ b/buildscripts/05_android
@@ -22,7 +22,7 @@ my $PLATFORM = "android-19";
 
 my %ABI = (
    # Target triple                                     Emulator binary            Image ABI      NDK ABI
-   'arm-linux-androideabi' =>                         ['emulator',                'armeabi-v7a', 'armeabi-v7a'],
+   'arm-linux-androideabi' => ($ENV{TRAVIS} ? undef : ['emulator',                'armeabi-v7a', 'armeabi-v7a']),
    'aarch64-linux-android' => ($ENV{TRAVIS} ? undef : ['emulator64-ranchu-arm64', 'armeabi-v7a', 'arm64-v8a']),
    'i686-linux-android'    => ($ENV{TRAVIS} ? undef : ['emulator',                'x86',         'x86']),
 );

--- a/buildscripts/dependencies.pl
+++ b/buildscripts/dependencies.pl
@@ -25,7 +25,7 @@ my ($toxcore_user, $toxcore_repo) = split '/', $toxcore;
 # External dependencies.
 (
    ["https://github.com/yasm", "yasm", "master", @common],
-   ["https://chromium.googlesource.com/webm", "libvpx", "v1.5.0",
+   ["https://github.com/webmproject", "libvpx", "v1.6.0",
       '--disable-examples',
       '--disable-unit-tests',
       (not_on qr/^arm/, "--enable-pic"),
@@ -40,7 +40,7 @@ my ($toxcore_user, $toxcore_repo) = split '/', $toxcore;
       (only_on qr/i686-linux-android/   , '--target=x86-android-gcc'  ),
       (only_on qr/x86_64-linux-android/ , '--target=x86_64-android-gcc'  ),
    ],
-   ["git://git.xiph.org", "opus", "master", @common],
+   ["https://github.com/xiph", "opus", "master", @common],
    ["https://github.com/jedisct1", "libsodium", "stable", @common,
       '--enable-minimal',
       '--disable-pie',

--- a/buildscripts/patches/c-toxcore.patch
+++ b/buildscripts/patches/c-toxcore.patch
@@ -1,10 +1,10 @@
 diff --git a/toxcore/TCP_server.c b/toxcore/TCP_server.c
-index d7401de..1ba77a2 100644
+index a078da9..ced28ba 100644
 --- a/toxcore/TCP_server.c
 +++ b/toxcore/TCP_server.c
-@@ -32,6 +32,10 @@
- 
- #include "util.h"
+@@ -68,6 +68,10 @@ size_t tcp_server_listen_count(const TCP_Server *tcp_server)
+     return tcp_server->num_listening_socks;
+ }
  
 +#ifndef EPOLLRDHUP
 +#define EPOLLRDHUP 0x2000

--- a/buildscripts/patches/libvpx.patch
+++ b/buildscripts/patches/libvpx.patch
@@ -1,0 +1,254 @@
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index 4f0071b..f8e7b69 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -918,92 +918,6 @@ process_common_toolchain() {
+ 
+       asm_conversion_cmd="cat"
+ 
+-      case ${tgt_cc} in
+-        gcc)
+-          link_with_cc=gcc
+-          setup_gnu_toolchain
+-          arch_int=${tgt_isa##armv}
+-          arch_int=${arch_int%%te}
+-          check_add_asflags --defsym ARCHITECTURE=${arch_int}
+-          tune_cflags="-mtune="
+-          if [ ${tgt_isa} = "armv7" ] || [ ${tgt_isa} = "armv7s" ]; then
+-            if [ -z "${float_abi}" ]; then
+-              check_cpp <<EOF && float_abi=hard || float_abi=softfp
+-#ifndef __ARM_PCS_VFP
+-#error "not hardfp"
+-#endif
+-EOF
+-            fi
+-            check_add_cflags  -march=armv7-a -mfloat-abi=${float_abi}
+-            check_add_asflags -march=armv7-a -mfloat-abi=${float_abi}
+-
+-            if enabled neon || enabled neon_asm; then
+-              check_add_cflags -mfpu=neon #-ftree-vectorize
+-              check_add_asflags -mfpu=neon
+-            fi
+-          elif [ ${tgt_isa} = "arm64" ] || [ ${tgt_isa} = "armv8" ]; then
+-            check_add_cflags -march=armv8-a
+-            check_add_asflags -march=armv8-a
+-          else
+-            check_add_cflags -march=${tgt_isa}
+-            check_add_asflags -march=${tgt_isa}
+-          fi
+-
+-          enabled debug && add_asflags -g
+-          asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
+-          if enabled thumb; then
+-            asm_conversion_cmd="$asm_conversion_cmd -thumb"
+-            check_add_cflags -mthumb
+-            check_add_asflags -mthumb -mimplicit-it=always
+-          fi
+-          ;;
+-        vs*)
+-          asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
+-          AS_SFX=.s
+-          msvs_arch_dir=arm-msvs
+-          disable_feature multithread
+-          disable_feature unit_tests
+-          vs_version=${tgt_cc##vs}
+-          if [ $vs_version -ge 12 ]; then
+-            # MSVC 2013 doesn't allow doing plain .exe projects for ARM,
+-            # only "AppContainerApplication" which requires an AppxManifest.
+-            # Therefore disable the examples, just build the library.
+-            disable_feature examples
+-          fi
+-          ;;
+-        rvct)
+-          CC=armcc
+-          AR=armar
+-          AS=armasm
+-          LD="${source_path}/build/make/armlink_adapter.sh"
+-          STRIP=arm-none-linux-gnueabi-strip
+-          NM=arm-none-linux-gnueabi-nm
+-          tune_cflags="--cpu="
+-          tune_asflags="--cpu="
+-          if [ -z "${tune_cpu}" ]; then
+-            if [ ${tgt_isa} = "armv7" ]; then
+-              if enabled neon || enabled neon_asm
+-              then
+-                check_add_cflags --fpu=softvfp+vfpv3
+-                check_add_asflags --fpu=softvfp+vfpv3
+-              fi
+-              check_add_cflags --cpu=Cortex-A8
+-              check_add_asflags --cpu=Cortex-A8
+-            else
+-              check_add_cflags --cpu=${tgt_isa##armv}
+-              check_add_asflags --cpu=${tgt_isa##armv}
+-            fi
+-          fi
+-          arch_int=${tgt_isa##armv}
+-          arch_int=${arch_int%%te}
+-          check_add_asflags --pd "\"ARCHITECTURE SETA ${arch_int}\""
+-          enabled debug && add_asflags -g
+-          add_cflags --gnu
+-          add_cflags --enum_is_int
+-          add_cflags --wchar32
+-          ;;
+-      esac
+-
+       case ${tgt_os} in
+         none*)
+           disable_feature multithread
+@@ -1015,10 +929,16 @@ EOF
+             die "Must specify --sdk-path for Android builds."
+           fi
+ 
++          if [ ${tgt_isa} = "arm64" ]; then
++            TRIPLE=aarch64-linux-android
++          else
++            TRIPLE=arm-linux-androideabi
++          fi
++
+           SDK_PATH=${sdk_path}
+           COMPILER_LOCATION=`find "${SDK_PATH}" \
+-                             -name "arm-linux-androideabi-gcc*" -print -quit`
+-          TOOLCHAIN_PATH=${COMPILER_LOCATION%/*}/arm-linux-androideabi-
++                             -name "${TRIPLE}-gcc*" -print -quit`
++          TOOLCHAIN_PATH=${COMPILER_LOCATION%/*}/${TRIPLE}-
+           CC=${TOOLCHAIN_PATH}gcc
+           CXX=${TOOLCHAIN_PATH}g++
+           AR=${TOOLCHAIN_PATH}ar
+@@ -1041,9 +961,11 @@ EOF
+             add_ldflags "--sysroot=${alt_libc}"
+           fi
+ 
+-          # linker flag that routes around a CPU bug in some
+-          # Cortex-A8 implementations (NDK Dev Guide)
+-          add_ldflags "-Wl,--fix-cortex-a8"
++          if [ ${tgt_isa} != "arm64" ]; then
++            # linker flag that routes around a CPU bug in some
++            # Cortex-A8 implementations (NDK Dev Guide)
++            add_ldflags "-Wl,--fix-cortex-a8"
++          fi
+ 
+           enable_feature pic
+           soft_enable realtime_only
+@@ -1137,6 +1059,92 @@ EOF
+           fi
+           ;;
+       esac
++
++      case ${tgt_cc} in
++        gcc)
++          link_with_cc=gcc
++          setup_gnu_toolchain
++          arch_int=${tgt_isa##armv}
++          arch_int=${arch_int%%te}
++          check_add_asflags --defsym ARCHITECTURE=${arch_int}
++          tune_cflags="-mtune="
++          if [ ${tgt_isa} = "armv7" ] || [ ${tgt_isa} = "armv7s" ]; then
++            if [ -z "${float_abi}" ]; then
++              check_cpp <<EOF && float_abi=hard || float_abi=softfp
++#ifndef __ARM_PCS_VFP
++#error "not hardfp"
++#endif
++EOF
++            fi
++            check_add_cflags  -march=armv7-a -mfloat-abi=${float_abi}
++            check_add_asflags -march=armv7-a -mfloat-abi=${float_abi}
++
++            if enabled neon || enabled neon_asm; then
++              check_add_cflags -mfpu=neon #-ftree-vectorize
++              check_add_asflags -mfpu=neon
++            fi
++          elif [ ${tgt_isa} = "arm64" ] || [ ${tgt_isa} = "armv8" ]; then
++            check_add_cflags -march=armv8-a
++            check_add_asflags -march=armv8-a
++          else
++            check_add_cflags -march=${tgt_isa}
++            check_add_asflags -march=${tgt_isa}
++          fi
++
++          enabled debug && add_asflags -g
++          asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
++          if enabled thumb; then
++            asm_conversion_cmd="$asm_conversion_cmd -thumb"
++            check_add_cflags -mthumb
++            check_add_asflags -mthumb -mimplicit-it=always
++          fi
++          ;;
++        vs*)
++          asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
++          AS_SFX=.s
++          msvs_arch_dir=arm-msvs
++          disable_feature multithread
++          disable_feature unit_tests
++          vs_version=${tgt_cc##vs}
++          if [ $vs_version -ge 12 ]; then
++            # MSVC 2013 doesn't allow doing plain .exe projects for ARM,
++            # only "AppContainerApplication" which requires an AppxManifest.
++            # Therefore disable the examples, just build the library.
++            disable_feature examples
++          fi
++          ;;
++        rvct)
++          CC=armcc
++          AR=armar
++          AS=armasm
++          LD="${source_path}/build/make/armlink_adapter.sh"
++          STRIP=arm-none-linux-gnueabi-strip
++          NM=arm-none-linux-gnueabi-nm
++          tune_cflags="--cpu="
++          tune_asflags="--cpu="
++          if [ -z "${tune_cpu}" ]; then
++            if [ ${tgt_isa} = "armv7" ]; then
++              if enabled neon || enabled neon_asm
++              then
++                check_add_cflags --fpu=softvfp+vfpv3
++                check_add_asflags --fpu=softvfp+vfpv3
++              fi
++              check_add_cflags --cpu=Cortex-A8
++              check_add_asflags --cpu=Cortex-A8
++            else
++              check_add_cflags --cpu=${tgt_isa##armv}
++              check_add_asflags --cpu=${tgt_isa##armv}
++            fi
++          fi
++          arch_int=${tgt_isa##armv}
++          arch_int=${arch_int%%te}
++          check_add_asflags --pd "\"ARCHITECTURE SETA ${arch_int}\""
++          enabled debug && add_asflags -g
++          add_cflags --gnu
++          add_cflags --enum_is_int
++          add_cflags --wchar32
++          ;;
++      esac
+       ;;
+     mips*)
+       link_with_cc=gcc
+@@ -1188,6 +1196,17 @@ EOF
+           LD=${LD:-${CROSS}gcc}
+           CROSS=${CROSS-g}
+           ;;
++        android*)
++          case ${toolchain} in
++            x86_64*)
++              CROSS=${CROSS:-x86_64-linux-android-}
++              ;;
++            *)
++              CROSS=${CROSS:-i686-linux-android-}
++              ;;
++          esac
++          add_asflags -D__ANDROID__
++          ;;
+         os2)
+           disable_feature pic
+           AS=${AS:-nasm}
+diff --git a/configure b/configure
+index f82ee04..5de9866 100755
+--- a/configure
++++ b/configure
+@@ -97,6 +97,7 @@ EOF
+ 
+ # all_platforms is a list of all supported target platforms. Maintain
+ # alphabetically by architecture, generic-gnu last.
++all_platforms="${all_platforms} arm64-android-gcc"
+ all_platforms="${all_platforms} arm64-darwin-gcc"
+ all_platforms="${all_platforms} arm64-linux-gcc"
+ all_platforms="${all_platforms} armv6-linux-rvct"

--- a/src/main/cpp/ToxCrypto/generated/errors.cpp
+++ b/src/main/cpp/ToxCrypto/generated/errors.cpp
@@ -1,7 +1,5 @@
 #include "../ToxCrypto.h"
 
-#ifdef TOX_DEFINED
-
 HANDLE ("Decryption", DECRYPTION)
 {
   switch (error)
@@ -38,5 +36,3 @@ HANDLE ("KeyDerivation", KEY_DERIVATION)
     }
   return unhandled ();
 }
-
-#endif


### PR DESCRIPTION
We now also use the make_standalone_toolchain.py script instead of the
deprecated shell script.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/4)
<!-- Reviewable:end -->
