### PR TITLE
Our own \/ type won't support .get, but it does .toOption.

### DIFF
--- a/src/test/java/im/tox/core/typesafe/KeyCompanionTest.scala
+++ b/src/test/java/im/tox/core/typesafe/KeyCompanionTest.scala
@@ -17,19 +17,19 @@ abstract class KeyCompanionTest[T <: AnyVal, S <: Security](
         Gen.choose('A', 'F')
       )
     ).map(new String(_))) { string =>
-      companion.fromHexString(string).get
+      companion.fromHexString(string).toOption.get
     }
   }
 
   test("toString") {
     forAll { (self: T) =>
-      assert(companion.equals(companion.fromHexString(self.toString).get, self))
+      assert(companion.equals(companion.fromHexString(self.toString).toOption.get, self))
     }
   }
 
   test("toHexString") {
     forAll { (self: T) =>
-      assert(companion.equals(companion.fromHexString(companion.toHexString(self)).get, self))
+      assert(companion.equals(companion.fromHexString(companion.toHexString(self)).toOption.get, self))
     }
   }
 

--- a/src/test/java/im/tox/tox4j/DhtNode.scala
+++ b/src/test/java/im/tox/tox4j/DhtNode.scala
@@ -11,7 +11,7 @@ final case class DhtNode(ipv4: String, ipv6: String, udpPort: Port, tcpPort: Por
       ipv4, ipv6,
       Port.unsafeFromInt(udpPort),
       Port.unsafeFromInt(tcpPort),
-      ToxPublicKey.fromValue(ToxCoreTestBase.parsePublicKey(dhtId)).get
+      ToxPublicKey.fromValue(ToxCoreTestBase.parsePublicKey(dhtId)).toOption.get
     )
   }
 

--- a/src/test/java/im/tox/tox4j/ToxCoreTest.scala
+++ b/src/test/java/im/tox/tox4j/ToxCoreTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.FunSuite
 @SuppressWarnings(Array("org.wartremover.warts.Equals"))
 final class ToxCoreTest extends FunSuite with ToxTestMixin {
 
-  val publicKey: ToxPublicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).get
+  val publicKey: ToxPublicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).toOption.get
   val eventListener: ToxCoreEventAdapter[Unit] = new ToxCoreEventAdapter[Unit]
 
   test("ToxNew") {
@@ -151,7 +151,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("GetAndSetName") {
     withToxUnit { tox =>
       assert(tox.getName.value.isEmpty)
-      tox.setName(ToxNickname.fromString("myname").get)
+      tox.setName(ToxNickname.fromString("myname").toOption.get)
       assert(new String(tox.getName.value) == "myname")
     }
   }
@@ -159,7 +159,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("SetNameMinSize") {
     withToxUnit { tox =>
       val array = ToxCoreTestBase.randomBytes(1)
-      tox.setName(ToxNickname.fromValue(array).get)
+      tox.setName(ToxNickname.fromValue(array).toOption.get)
       assert(tox.getName.value sameElements array)
     }
   }
@@ -167,7 +167,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("SetNameMaxSize") {
     withToxUnit { tox =>
       val array = ToxCoreTestBase.randomBytes(ToxCoreConstants.MaxNameLength)
-      tox.setName(ToxNickname.fromValue(array).get)
+      tox.setName(ToxNickname.fromValue(array).toOption.get)
       assert(tox.getName.value sameElements array)
     }
   }
@@ -176,7 +176,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
     withToxUnit { tox =>
       (1 to ToxCoreConstants.MaxNameLength) foreach { i =>
         val array = ToxCoreTestBase.randomBytes(i)
-        tox.setName(ToxNickname.fromValue(array).get)
+        tox.setName(ToxNickname.fromValue(array).toOption.get)
         assert(tox.getName.value sameElements array)
       }
     }
@@ -185,9 +185,9 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("UnsetName") {
     withToxUnit { tox =>
       assert(tox.getName.value.isEmpty)
-      tox.setName(ToxNickname.fromString("myname").get)
+      tox.setName(ToxNickname.fromString("myname").toOption.get)
       assert(tox.getName.value.nonEmpty)
-      tox.setName(ToxNickname.fromString("").get)
+      tox.setName(ToxNickname.fromString("").toOption.get)
       assert(tox.getName.value.isEmpty)
     }
   }
@@ -195,7 +195,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("GetAndSetStatusMessage") {
     withToxUnit { tox =>
       assert(tox.getStatusMessage.value.isEmpty)
-      tox.setStatusMessage(ToxStatusMessage.fromString("message").get)
+      tox.setStatusMessage(ToxStatusMessage.fromString("message").toOption.get)
       assert(new String(tox.getStatusMessage.value) == "message")
     }
   }
@@ -203,7 +203,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("SetStatusMessageMinSize") {
     withToxUnit { tox =>
       val array = ToxCoreTestBase.randomBytes(1)
-      tox.setStatusMessage(ToxStatusMessage.fromValue(array).get)
+      tox.setStatusMessage(ToxStatusMessage.fromValue(array).toOption.get)
       assert(tox.getStatusMessage.value sameElements array)
     }
   }
@@ -211,7 +211,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("SetStatusMessageMaxSize") {
     withToxUnit { tox =>
       val array = ToxCoreTestBase.randomBytes(ToxCoreConstants.MaxStatusMessageLength)
-      tox.setStatusMessage(ToxStatusMessage.fromValue(array).get)
+      tox.setStatusMessage(ToxStatusMessage.fromValue(array).toOption.get)
       assert(tox.getStatusMessage.value sameElements array)
     }
   }
@@ -220,7 +220,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
     withToxUnit { tox =>
       (1 to ToxCoreConstants.MaxStatusMessageLength) foreach { i =>
         val array = ToxCoreTestBase.randomBytes(i)
-        tox.setStatusMessage(ToxStatusMessage.fromValue(array).get)
+        tox.setStatusMessage(ToxStatusMessage.fromValue(array).toOption.get)
         assert(tox.getStatusMessage.value sameElements array)
       }
     }
@@ -229,9 +229,9 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
   test("UnsetStatusMessage") {
     withToxUnit { tox =>
       assert(tox.getStatusMessage.value.isEmpty)
-      tox.setStatusMessage(ToxStatusMessage.fromString("message").get)
+      tox.setStatusMessage(ToxStatusMessage.fromString("message").toOption.get)
       assert(tox.getStatusMessage.value.nonEmpty)
-      tox.setStatusMessage(ToxStatusMessage.fromString("").get)
+      tox.setStatusMessage(ToxStatusMessage.fromString("").toOption.get)
       assert(tox.getStatusMessage.value.isEmpty)
     }
   }
@@ -252,7 +252,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
         withToxUnit { friend =>
           val friendNumber = tox.addFriend(
             friend.getAddress,
-            ToxFriendRequestMessage.fromString("heyo").get
+            ToxFriendRequestMessage.fromString("heyo").toOption.get
           )
           assert(friendNumber == i)
         }

--- a/src/test/java/im/tox/tox4j/av/callbacks/CallCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/av/callbacks/CallCallbackTest.scala
@@ -41,7 +41,7 @@ final class CallCallbackTest extends AutoTestSuite with ToxExceptionChecks {
           }
           // Say "No thanks" and stop talking.
           debug(state, s"Got a call from ${state.id(friendNumber)}; rejecting")
-          tox.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("No thanks").get)
+          tox.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("No thanks").toOption.get)
           state.finish
         }
       } else {

--- a/src/test/java/im/tox/tox4j/bench/ToxBenchBase.scala
+++ b/src/test/java/im/tox/tox4j/bench/ToxBenchBase.scala
@@ -130,8 +130,8 @@ object ToxBenchBase {
    */
   def makeToxWithFriends(friendCount: Int): ToxCore = {
     val tox = ToxCoreImplFactory(toxOptions)
-    tox.setName(ToxNickname.fromValue(Array.ofDim(ToxCoreConstants.MaxNameLength)).get)
-    tox.setStatusMessage(ToxStatusMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxStatusMessageLength)).get)
+    tox.setName(ToxNickname.fromValue(Array.ofDim(ToxCoreConstants.MaxNameLength)).toOption.get)
+    tox.setStatusMessage(ToxStatusMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxStatusMessageLength)).toOption.get)
     friendKeys(friendCount) foreach tox.addFriendNorequest
     tox
   }
@@ -274,7 +274,7 @@ object ToxBenchBase {
     }
   }
 
-  val names: Gen[ToxNickname] = nameLengths.map(Array.ofDim[Byte]).map(ToxNickname.fromValue(_).get)
-  val statusMessages: Gen[ToxStatusMessage] = statusMessageLengths.map(Array.ofDim[Byte]).map(ToxStatusMessage.fromValue(_).get)
+  val names: Gen[ToxNickname] = nameLengths.map(Array.ofDim[Byte]).map(ToxNickname.fromValue(_).toOption.get)
+  val statusMessages: Gen[ToxStatusMessage] = statusMessageLengths.map(Array.ofDim[Byte]).map(ToxStatusMessage.fromValue(_).toOption.get)
 
 }

--- a/src/test/java/im/tox/tox4j/core/LoadSaveTest.scala
+++ b/src/test/java/im/tox/tox4j/core/LoadSaveTest.scala
@@ -43,9 +43,9 @@ final class LoadSaveTest extends FunSuite {
       override def change(tox: ToxCore): Boolean = {
         expected =
           if (expected.value == null) {
-            ToxNickname.fromString("").get
+            ToxNickname.fromString("").toOption.get
           } else {
-            ToxNickname.fromValue(ToxCoreTestBase.randomBytes(expected.value.length + 1)).get
+            ToxNickname.fromValue(ToxCoreTestBase.randomBytes(expected.value.length + 1)).toOption.get
           }
         tox.setName(expected)
         expected.value.length < ToxCoreConstants.MaxNameLength
@@ -63,9 +63,9 @@ final class LoadSaveTest extends FunSuite {
 
       override def change(tox: ToxCore): Boolean = {
         if (expected.value == null) {
-          expected = ToxStatusMessage.fromString("").get
+          expected = ToxStatusMessage.fromString("").toOption.get
         } else {
-          expected = ToxStatusMessage.fromValue(ToxCoreTestBase.randomBytes(expected.value.length + 1)).get
+          expected = ToxStatusMessage.fromValue(ToxCoreTestBase.randomBytes(expected.value.length + 1)).toOption.get
         }
         tox.setStatusMessage(expected)
         expected.value.length < ToxCoreConstants.MaxNameLength
@@ -117,7 +117,7 @@ final class LoadSaveTest extends FunSuite {
         withToxUnit { toxFriend =>
           expected = tox.addFriend(
             toxFriend.getAddress,
-            ToxFriendRequestMessage.fromString("hello").get
+            ToxFriendRequestMessage.fromString("hello").toOption.get
           )
         }
         false

--- a/src/test/java/im/tox/tox4j/core/ToxCoreTest.scala
+++ b/src/test/java/im/tox/tox4j/core/ToxCoreTest.scala
@@ -21,7 +21,7 @@ final class ToxCoreTest extends FlatSpec with PropertyChecks {
             withToxUnit { friend =>
               val friendNumber = tox.addFriend(
                 friend.getAddress,
-                ToxFriendRequestMessage.fromValue(message).get
+                ToxFriendRequestMessage.fromValue(message).toOption.get
               )
               assert(friendNumber == i)
             }

--- a/src/test/java/im/tox/tox4j/core/bench/CoreCallbackTimingBench.scala
+++ b/src/test/java/im/tox/tox4j/core/bench/CoreCallbackTimingBench.scala
@@ -14,8 +14,8 @@ final class CoreCallbackTimingBench extends TimingReport {
   private val eventListener = new ToxCoreEventAdapter[Unit]
 
   private val friendNumber = ToxFriendNumber.fromInt(1).get
-  private val publicKey = ToxPublicKey.fromValue(Array.ofDim[Byte](ToxCoreConstants.PublicKeySize)).get
-  private val nickname = ToxNickname.fromValue(Array.ofDim[Byte](ToxNickname.MaxSize)).get
+  private val publicKey = ToxPublicKey.fromValue(Array.ofDim[Byte](ToxCoreConstants.PublicKeySize)).toOption.get
+  private val nickname = ToxNickname.fromValue(Array.ofDim[Byte](ToxNickname.MaxSize)).toOption.get
   private val data = Array.ofDim[Byte](ToxCoreConstants.MaxCustomPacketSize)
 
   def invokePerformance(method: String, f: ToxCoreImpl => Unit): Unit = {

--- a/src/test/java/im/tox/tox4j/core/bench/FriendListTimingBench.scala
+++ b/src/test/java/im/tox/tox4j/core/bench/FriendListTimingBench.scala
@@ -34,7 +34,7 @@ final class FriendListTimingBench extends TimingReport {
     measure method "addFriend" in {
       using(friends(100) map friendAddresses, toxInstance.cached) tearDown clearFriendList in {
         case (friendList, tox) =>
-          friendList foreach (tox.addFriend(_, ToxFriendRequestMessage.fromValue(Array.ofDim(1)).get))
+          friendList foreach (tox.addFriend(_, ToxFriendRequestMessage.fromValue(Array.ofDim(1)).toOption.get))
       }
     }
 

--- a/src/test/java/im/tox/tox4j/core/bench/ToxCoreTimingBench.scala
+++ b/src/test/java/im/tox/tox4j/core/bench/ToxCoreTimingBench.scala
@@ -10,7 +10,7 @@ import im.tox.tox4j.testing.GetDisjunction._
 final class ToxCoreTimingBench extends TimingReport {
 
   private val port = Port.fromInt(8080).get
-  private val publicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).get
+  private val publicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).toOption.get
 
   timing.of[ToxCore] {
 

--- a/src/test/java/im/tox/tox4j/core/callbacks/CoreInvokeTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/CoreInvokeTest.scala
@@ -61,7 +61,7 @@ final class CoreInvokeTest extends FunSuite with PropertyChecks {
     Arbitrary(Gen.const(ToxPublicKey.Size).map(Array.ofDim[Byte]).map { array =>
       random.nextBytes(array)
       array(array.length - 1) = 0
-      ToxPublicKey.fromValue(array).get
+      ToxPublicKey.fromValue(array).toOption.get
     })
   }
 

--- a/src/test/java/im/tox/tox4j/core/callbacks/FilePauseResumeTestBase.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FilePauseResumeTestBase.scala
@@ -71,7 +71,7 @@ abstract class FilePauseResumeTestBase extends AliceBobTest {
               ToxFileKind.DATA,
               fileData.length,
               ToxFileId.empty,
-              ToxFilename.fromValue(("file for " + expectedFriendName + ".png").getBytes).get
+              ToxFilename.fromValue(("file for " + expectedFriendName + ".png").getBytes).toOption.get
             )
             state.map(_.copy(
               fileId = tox.getFileFileId(friendNumber, aliceSentFileNumber),
@@ -160,7 +160,7 @@ abstract class FilePauseResumeTestBase extends AliceBobTest {
         } else if (control == ToxFileControl.PAUSE) {
           state.addTask { (tox, av, state) =>
             tox.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0,
-              ToxFriendMessage.fromValue("Please resume the file transfer".getBytes).get)
+              ToxFriendMessage.fromValue("Please resume the file transfer".getBytes).toOption.get)
             state.map(_.copy(aliceShouldPause = 0))
           }
         } else {
@@ -172,7 +172,7 @@ abstract class FilePauseResumeTestBase extends AliceBobTest {
           state.addTask { (tox, av, state) =>
             debug("request to resume file transmission")
             tox.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0,
-              ToxFriendMessage.fromValue("Please resume the file transfer".getBytes).get)
+              ToxFriendMessage.fromValue("Please resume the file transfer".getBytes).toOption.get)
             state
           }
         } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FilePauseResumeWithResendTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FilePauseResumeWithResendTest.scala
@@ -24,7 +24,7 @@ final class FilePauseResumeWithResendTest extends FilePauseResumeTestBase {
             ToxFileKind.DATA,
             fileData.length,
             fileId,
-            ToxFilename.fromValue(("file for " + expectedFriendName + ".png").getBytes).get
+            ToxFilename.fromValue(("file for " + expectedFriendName + ".png").getBytes).toOption.get
           )
         )
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FileRecvCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FileRecvCallbackTest.scala
@@ -31,7 +31,7 @@ final class FileRecvCallbackTest extends AliceBobTest {
             ToxFileKind.DATA,
             state.get.length,
             ToxFileId.empty,
-            ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).get
+            ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).toOption.get
           )
           state
         }

--- a/src/test/java/im/tox/tox4j/core/callbacks/FileResumeAfterRestartTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FileResumeAfterRestartTest.scala
@@ -61,7 +61,7 @@ final class FileResumeAfterRestartTest extends AliceBobTest {
               ToxFileKind.DATA,
               fileData.length,
               ToxFileId.empty,
-              ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).get
+              ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).toOption.get
             )
             fileId = tox.getFileFileId(friendNumber, aliceSentFileNumber)
             aliceAddress = tox.getAddress
@@ -79,7 +79,7 @@ final class FileResumeAfterRestartTest extends AliceBobTest {
           debug("See alice go off-line")
           state.addTask { (tox, av, state) =>
             tox.deleteFriend(friendNumber)
-            tox.addFriend(aliceAddress, ToxFriendRequestMessage.fromValue("Please add me back".getBytes).get)
+            tox.addFriend(aliceAddress, ToxFriendRequestMessage.fromValue("Please add me back".getBytes).toOption.get)
             state
           }
         }

--- a/src/test/java/im/tox/tox4j/core/callbacks/FileTransferTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FileTransferTest.scala
@@ -42,7 +42,7 @@ final class FileTransferTest extends AliceBobTest {
             ToxFileKind.DATA,
             fileData.length,
             ToxFileId.empty,
-            ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).get
+            ToxFilename.fromValue(s"file for $expectedFriendName.png".getBytes).toOption.get
           )
           state.map(_.copy(sentFileNumber = sentFileNumber))
         }

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendLosslessPacketCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendLosslessPacketCallbackTest.scala
@@ -18,7 +18,7 @@ final class FriendLosslessPacketCallbackTest extends AliceBobTest {
         state.addTask { (tox, av, state) =>
           val packet = s"_My name is $selfName".getBytes
           packet(0) = 160.toByte
-          tox.friendSendLosslessPacket(friendNumber, ToxLosslessPacket.fromValue(packet).get)
+          tox.friendSendLosslessPacket(friendNumber, ToxLosslessPacket.fromValue(packet).toOption.get)
           state
         }
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendLossyPacketCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendLossyPacketCallbackTest.scala
@@ -18,7 +18,7 @@ final class FriendLossyPacketCallbackTest extends AliceBobTest {
         state.addTask { (tox, av, state) =>
           val packet = s"_My name is $selfName".getBytes
           packet(0) = 200.toByte
-          tox.friendSendLossyPacket(friendNumber, ToxLossyPacket.fromValue(packet).get)
+          tox.friendSendLossyPacket(friendNumber, ToxLossyPacket.fromValue(packet).toOption.get)
           state
         }
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendMessageCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendMessageCallbackTest.scala
@@ -17,7 +17,7 @@ final class FriendMessageCallbackTest extends AliceBobTest {
       if (connectionStatus != ToxConnection.NONE) {
         state.addTask { (tox, av, state) =>
           tox.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0,
-            ToxFriendMessage.fromValue(s"My name is $selfName".getBytes).get)
+            ToxFriendMessage.fromValue(s"My name is $selfName".getBytes).toOption.get)
           state
         }
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendNameCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendNameCallbackTest.scala
@@ -16,7 +16,7 @@ final class FriendNameCallbackTest extends AliceBobTest {
       super.friendConnectionStatus(friendNumber, connectionStatus)(state)
       if (connectionStatus != ToxConnection.NONE) {
         state.addTask { (tox, av, state) =>
-          tox.setName(ToxNickname.fromValue(selfName.getBytes).get)
+          tox.setName(ToxNickname.fromValue(selfName.getBytes).toOption.get)
           state
         }
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendReadReceiptCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendReadReceiptCallbackTest.scala
@@ -25,7 +25,7 @@ final class FriendReadReceiptCallbackTest extends AliceBobTest {
             case (receipts, i) =>
               val receipt = tox.friendSendMessage(
                 friendNumber, ToxMessageType.NORMAL, 0,
-                ToxFriendMessage.fromString(String.valueOf(i)).get
+                ToxFriendMessage.fromString(String.valueOf(i)).toOption.get
               )
               assert(!receipts.contains(receipt))
               receipts + receipt

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendRequestCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendRequestCallbackTest.scala
@@ -16,7 +16,7 @@ final class FriendRequestCallbackTest extends AliceBobTest {
     override def setup(tox: ToxCore)(state: ChatState): ChatState = {
       tox.deleteFriend(AliceBobTestBase.FriendNumber)
       if (isAlice) {
-        tox.addFriend(expectedFriendAddress, ToxFriendRequestMessage.fromString(s"Hey this is $selfName").get)
+        tox.addFriend(expectedFriendAddress, ToxFriendRequestMessage.fromString(s"Hey this is $selfName").toOption.get)
       }
       state
     }

--- a/src/test/java/im/tox/tox4j/core/callbacks/FriendStatusMessageCallbackTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/FriendStatusMessageCallbackTest.scala
@@ -16,7 +16,7 @@ final class FriendStatusMessageCallbackTest extends AliceBobTest {
       super.friendConnectionStatus(friendNumber, connectionStatus)(state)
       if (connectionStatus != ToxConnection.NONE) {
         state.addTask { (tox, av, state) =>
-          tox.setStatusMessage(ToxStatusMessage.fromString(s"I like $expectedFriendName").get)
+          tox.setStatusMessage(ToxStatusMessage.fromString(s"I like $expectedFriendName").toOption.get)
           state
         }
       } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/NameEmptyTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/NameEmptyTest.scala
@@ -21,7 +21,7 @@ final class NameEmptyTest extends AliceBobTest {
           assert(name.value.isEmpty)
 
           state.addTask { (tox, av, state) =>
-            tox.setName(ToxNickname.fromString("One").get)
+            tox.setName(ToxNickname.fromString("One").toOption.get)
             state
           }.set(1)
 
@@ -29,7 +29,7 @@ final class NameEmptyTest extends AliceBobTest {
           assert(new String(name.value) == "One")
 
           state.addTask { (tox, av, state) =>
-            tox.setName(ToxNickname.fromString("").get)
+            tox.setName(ToxNickname.fromString("").toOption.get)
             state
           }.set(2)
 

--- a/src/test/java/im/tox/tox4j/core/callbacks/StatusMessageEmptyTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/StatusMessageEmptyTest.scala
@@ -20,7 +20,7 @@ final class StatusMessageEmptyTest extends AliceBobTest {
           assert(message.value.isEmpty)
           if (isAlice) {
             nextState.addTask { (tox, av, state) =>
-              tox.setStatusMessage(ToxStatusMessage.fromString("One").get)
+              tox.setStatusMessage(ToxStatusMessage.fromString("One").toOption.get)
               state
             }
           } else {
@@ -32,13 +32,13 @@ final class StatusMessageEmptyTest extends AliceBobTest {
           if (isAlice) {
             assert(new String(message.value) == "Two")
             nextState.addTask { (tox, av, state) =>
-              tox.setStatusMessage(ToxStatusMessage.fromString("").get)
+              tox.setStatusMessage(ToxStatusMessage.fromString("").toOption.get)
               state
             }
           } else {
             assert(new String(message.value) == "One")
             nextState.addTask { (tox, av, state) =>
-              tox.setStatusMessage(ToxStatusMessage.fromString("Two").get)
+              tox.setStatusMessage(ToxStatusMessage.fromString("Two").toOption.get)
               state
             }
           }
@@ -48,7 +48,7 @@ final class StatusMessageEmptyTest extends AliceBobTest {
           assert(message.value.isEmpty)
           if (isBob) {
             nextState.addTask { (tox, av, state) =>
-              tox.setStatusMessage(ToxStatusMessage.fromString("").get)
+              tox.setStatusMessage(ToxStatusMessage.fromString("").toOption.get)
               state
             }
           } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/ToxCoreEventAdapterTest.scala
+++ b/src/test/java/im/tox/tox4j/core/callbacks/ToxCoreEventAdapterTest.scala
@@ -24,7 +24,7 @@ final class ToxCoreEventAdapterTest extends FunSuite {
   }
 
   test[FileRecv] {
-    listener.fileRecv(friendNumber, 0, ToxFileKind.DATA, 0, ToxFilename.fromString("").get)(())
+    listener.fileRecv(friendNumber, 0, ToxFileKind.DATA, 0, ToxFilename.fromString("").toOption.get)(())
   }
 
   test[FileRecvChunk] {
@@ -40,18 +40,18 @@ final class ToxCoreEventAdapterTest extends FunSuite {
   }
 
   test[FriendMessage] {
-    listener.friendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").get)(())
+    listener.friendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").toOption.get)(())
   }
 
   test[FriendName] {
-    listener.friendName(friendNumber, ToxNickname.fromString("").get)(())
+    listener.friendName(friendNumber, ToxNickname.fromString("").toOption.get)(())
   }
 
   test[FriendRequest] {
     listener.friendRequest(
       ToxPublicKey.unsafeFromValue(null),
       0,
-      ToxFriendRequestMessage.fromString("").get
+      ToxFriendRequestMessage.fromString("").toOption.get
     )(())
   }
 
@@ -60,7 +60,7 @@ final class ToxCoreEventAdapterTest extends FunSuite {
   }
 
   test[FriendStatusMessage] {
-    listener.friendStatusMessage(friendNumber, ToxStatusMessage.fromString("").get)(())
+    listener.friendStatusMessage(friendNumber, ToxStatusMessage.fromString("").toOption.get)(())
   }
 
   test[FriendTyping] {
@@ -68,11 +68,11 @@ final class ToxCoreEventAdapterTest extends FunSuite {
   }
 
   test[FriendLosslessPacket] {
-    listener.friendLosslessPacket(friendNumber, ToxLosslessPacket.fromByteArray(160, Array.empty).get)(())
+    listener.friendLosslessPacket(friendNumber, ToxLosslessPacket.fromByteArray(160, Array.empty).toOption.get)(())
   }
 
   test[FriendLossyPacket] {
-    listener.friendLossyPacket(friendNumber, ToxLossyPacket.fromByteArray(200, Array.empty).get)(())
+    listener.friendLossyPacket(friendNumber, ToxLossyPacket.fromByteArray(200, Array.empty).toOption.get)(())
   }
 
   test[FriendReadReceipt] {

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxBootstrapExceptionTest.scala
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxBootstrapExceptionTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
 final class ToxBootstrapExceptionTest extends FunSuite with ToxTestMixin {
 
   private val host = "192.254.75.98"
-  private val publicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).get
+  private val publicKey = ToxPublicKey.fromValue(Array.ofDim(ToxCoreConstants.PublicKeySize)).toOption.get
   private val port = Port.fromInt(ToxCoreConstants.DefaultStartPort).get
 
   test("BootstrapBadPort1") {

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxFileSendExceptionTest.scala
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxFileSendExceptionTest.scala
@@ -14,14 +14,14 @@ final class ToxFileSendExceptionTest extends FunSuite with ToxTestMixin {
   test("FileSendNotConnected") {
     interceptWithTox(ToxFileSendException.Code.FRIEND_NOT_CONNECTED)(
       _.fileSend(friendNumber, ToxFileKind.DATA, 123, ToxFileId.empty,
-        ToxFilename.fromString("filename").get)
+        ToxFilename.fromString("filename").toOption.get)
     )
   }
 
   test("FileSendNotFound") {
     interceptWithTox(ToxFileSendException.Code.FRIEND_NOT_FOUND)(
       _.fileSend(badFriendNumber, ToxFileKind.DATA, 123, ToxFileId.empty,
-        ToxFilename.fromString("filename").get)
+        ToxFilename.fromString("filename").toOption.get)
     )
   }
 

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendAddExceptionTest.scala
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendAddExceptionTest.scala
@@ -15,7 +15,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
       ToxCoreImplFactory.withToxUnit(
         _.addFriend(
           ToxFriendAddress.unsafeFromValue(Array.ofDim(1)),
-          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).get
+          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).toOption.get
         )
       )
     }
@@ -26,7 +26,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
       ToxCoreImplFactory.withToxUnit(
         _.addFriend(
           ToxFriendAddress.unsafeFromValue(Array.ofDim(ToxCoreConstants.AddressSize - 1)),
-          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).get
+          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).toOption.get
         )
       )
     }
@@ -37,7 +37,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
       ToxCoreImplFactory.withToxUnit(
         _.addFriend(
           ToxFriendAddress.unsafeFromValue(Array.ofDim(ToxCoreConstants.AddressSize + 1)),
-          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).get
+          ToxFriendRequestMessage.fromValue(Array.ofDim(1)).toOption.get
         )
       )
     }
@@ -47,7 +47,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.NULL)(
       _.addFriend(
         ToxFriendAddress.unsafeFromValue(null),
-        ToxFriendRequestMessage.fromValue(Array.ofDim(1)).get
+        ToxFriendRequestMessage.fromValue(Array.ofDim(1)).toOption.get
       )
     )
   }
@@ -62,7 +62,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     ToxCoreImplFactory.withToxUnit(
       _.addFriend(
         validAddress,
-        ToxFriendRequestMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxFriendRequestLength - 1)).get
+        ToxFriendRequestMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxFriendRequestLength - 1)).toOption.get
       )
     )
   }
@@ -71,7 +71,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     ToxCoreImplFactory.withToxUnit(
       _.addFriend(
         validAddress,
-        ToxFriendRequestMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxFriendRequestLength)).get
+        ToxFriendRequestMessage.fromValue(Array.ofDim(ToxCoreConstants.MaxFriendRequestLength)).toOption.get
       )
     )
   }
@@ -89,7 +89,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.NO_MESSAGE)(
       _.addFriend(
         validAddress,
-        ToxFriendRequestMessage.fromString("").get
+        ToxFriendRequestMessage.fromString("").toOption.get
       )
     )
   }
@@ -98,7 +98,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.OWN_KEY) { tox =>
       tox.addFriend(
         tox.getAddress,
-        ToxFriendRequestMessage.fromString("hello").get
+        ToxFriendRequestMessage.fromString("hello").toOption.get
       )
     }
   }
@@ -107,11 +107,11 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.ALREADY_SENT) { tox =>
       tox.addFriend(
         validAddress,
-        ToxFriendRequestMessage.fromString("hello").get
+        ToxFriendRequestMessage.fromString("hello").toOption.get
       )
       tox.addFriend(
         validAddress,
-        ToxFriendRequestMessage.fromString("hello").get
+        ToxFriendRequestMessage.fromString("hello").toOption.get
       )
     }
   }
@@ -120,7 +120,7 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.BAD_CHECKSUM)(
       _.addFriend(
         ToxFriendAddress.unsafeFromValue(validAddress.value.updated(0, (validAddress.value(0) + 1).toByte)),
-        ToxFriendRequestMessage.fromString("hello").get
+        ToxFriendRequestMessage.fromString("hello").toOption.get
       )
     )
   }
@@ -129,9 +129,9 @@ final class ToxFriendAddExceptionTest extends FunSuite with ToxTestMixin {
     interceptWithTox(ToxFriendAddException.Code.SET_NEW_NOSPAM) { tox =>
       ToxCoreImplFactory.withToxUnit { friend =>
         friend.setNospam(12345678)
-        tox.addFriend(friend.getAddress, ToxFriendRequestMessage.fromString("hello").get)
+        tox.addFriend(friend.getAddress, ToxFriendRequestMessage.fromString("hello").toOption.get)
         friend.setNospam(87654321)
-        tox.addFriend(friend.getAddress, ToxFriendRequestMessage.fromString("hello").get)
+        tox.addFriend(friend.getAddress, ToxFriendRequestMessage.fromString("hello").toOption.get)
       }
     }
   }

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendCustomPacketExceptionTest.scala
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendCustomPacketExceptionTest.scala
@@ -12,25 +12,25 @@ final class ToxFriendCustomPacketExceptionTest extends FunSuite with ToxTestMixi
 
   test("SendLosslessPacketNotConnected") {
     interceptWithTox(ToxFriendCustomPacketException.Code.FRIEND_NOT_CONNECTED)(
-      _.friendSendLosslessPacket(friendNumber, ToxLosslessPacket.fromValue(Array[Byte](160.toByte, 0, 1, 2, 3)).get)
+      _.friendSendLosslessPacket(friendNumber, ToxLosslessPacket.fromValue(Array[Byte](160.toByte, 0, 1, 2, 3)).toOption.get)
     )
   }
 
   test("SendLossyPacketNotConnected") {
     interceptWithTox(ToxFriendCustomPacketException.Code.FRIEND_NOT_CONNECTED)(
-      _.friendSendLossyPacket(friendNumber, ToxLossyPacket.fromValue(200.toByte +: Array.ofDim[Byte](4)).get)
+      _.friendSendLossyPacket(friendNumber, ToxLossyPacket.fromValue(200.toByte +: Array.ofDim[Byte](4)).toOption.get)
     )
   }
 
   test("SendLosslessPacketNotFound") {
     interceptWithTox(ToxFriendCustomPacketException.Code.FRIEND_NOT_FOUND)(
-      _.friendSendLosslessPacket(badFriendNumber, ToxLosslessPacket.fromValue(Array[Byte](160.toByte, 0, 1, 2, 3)).get)
+      _.friendSendLosslessPacket(badFriendNumber, ToxLosslessPacket.fromValue(Array[Byte](160.toByte, 0, 1, 2, 3)).toOption.get)
     )
   }
 
   test("SendLossyPacketNotFound") {
     interceptWithTox(ToxFriendCustomPacketException.Code.FRIEND_NOT_FOUND)(
-      _.friendSendLossyPacket(badFriendNumber, ToxLossyPacket.fromValue(Array[Byte](200.toByte, 0, 1, 2, 3)).get)
+      _.friendSendLossyPacket(badFriendNumber, ToxLossyPacket.fromValue(Array[Byte](200.toByte, 0, 1, 2, 3)).toOption.get)
     )
   }
 

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendSendMessageExceptionTest.scala
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxFriendSendMessageExceptionTest.scala
@@ -12,13 +12,13 @@ final class ToxFriendSendMessageExceptionTest extends FunSuite with ToxTestMixin
 
   test("SendMessageNotFound") {
     interceptWithTox(ToxFriendSendMessageException.Code.FRIEND_NOT_FOUND)(
-      _.friendSendMessage(badFriendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").get)
+      _.friendSendMessage(badFriendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").toOption.get)
     )
   }
 
   test("SendMessageNotConnected") {
     interceptWithTox(ToxFriendSendMessageException.Code.FRIEND_NOT_CONNECTED)(
-      _.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").get)
+      _.friendSendMessage(friendNumber, ToxMessageType.NORMAL, 0, ToxFriendMessage.fromString("hello").toOption.get)
     )
   }
 

--- a/src/test/java/im/tox/tox4j/testing/autotest/ChatClient.scala
+++ b/src/test/java/im/tox/tox4j/testing/autotest/ChatClient.scala
@@ -94,7 +94,7 @@ class ChatClientT[T](val selfName: String, val expectedFriendName: String) exten
 
   var expectedFriendAddress: ToxFriendAddress = ToxFriendAddress.unsafeFromValue(null)
   protected def expectedFriendPublicKey: ToxPublicKey = {
-    ToxPublicKey.fromValue(expectedFriendAddress.value.slice(0, ToxPublicKey.Size)).get
+    ToxPublicKey.fromValue(expectedFriendAddress.value.slice(0, ToxPublicKey.Size)).toOption.get
   }
 
   protected def isAlice = selfName == "Alice"


### PR DESCRIPTION
So we stop using .get and use .toOption.get in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/34)
<!-- Reviewable:end -->
