### PR TITLE
Remove TOXAV from the linker flags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 install:
 - test -f _install/host/protobuf.stamp || scripts/build-host -j$(nproc || sysctl -n hw.ncpu) $PWD/_install/host/protobuf.stamp
-- if [ -e _git/toxcore ]; then (cd _git/toxcore && git pull); fi
+- if [ -e _git/toxcore ]; then (cd _git/toxcore && git reset --hard && git clean -fdx && git pull); fi
 
 script:
 - scripts/build-$TARGET -j$(nproc || sysctl -n hw.ncpu) $GOAL
@@ -55,7 +55,3 @@ after_success:
 
 before_cache:
 - rm -f android-ndk-*.zip
-
-branches:
-  only:
-  - master

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -182,7 +182,6 @@ if(LIBTOXCORE_FOUND)
   )
 else()
   target_link_libraries(${PROJECT_NAME}
-    ${TOXAV_STATIC_LIBRARIES}
     ${TOXCORE_STATIC_LIBRARIES}
   )
 endif()

--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -42,7 +42,7 @@ $(TOOLCHAIN)/toxcore.stamp: $(foreach f,$(shell cd $(SRCDIR)/toxcore && git ls-f
 $(TOOLCHAIN)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodium opus libvpx,$(TOOLCHAIN)/$i.stamp)
 	@$(PRE_RULE)
 	mkdir -p $(BUILDDIR)/$(notdir $<)
-	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE)
+	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE) -DMUST_BUILD_TOXAV=ON
 	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
 	mkdir -p $(@D) && touch $@
 	@$(POST_RULE)


### PR DESCRIPTION
The toxav library is gone. Everything is in toxcore now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/50)
<!-- Reviewable:end -->
