### PR TITLE
Add error enum for new PROXY_WITH_UDP error.

### DIFF
--- a/cpp/src/ToxCore/generated/errors.cpp
+++ b/cpp/src/ToxCore/generated/errors.cpp
@@ -189,6 +189,7 @@ HANDLE ("New", NEW)
     failure_case (NEW, PROXY_BAD_PORT);
     failure_case (NEW, PROXY_BAD_TYPE);
     failure_case (NEW, PROXY_NOT_FOUND);
+    failure_case (NEW, PROXY_WITH_UDP);
     }
   return unhandled ();
 }


### PR DESCRIPTION
See https://github.com/TokTok/c-toxcore/pull/929.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/54)
<!-- Reviewable:end -->
