### PR TITLE
Remove `TOX_MAX_HOSTNAME_LENGTH` constant definition.

### DIFF
--- a/cpp/src/ToxCore/ToxCore.cpp
+++ b/cpp/src/ToxCore/ToxCore.cpp
@@ -21,7 +21,6 @@ reference_symbols_core ()
 #undef JAVA_METHOD_REF
 }
 
-#define TOX_MAX_HOSTNAME_LENGTH 255
 #define TOX_DEFAULT_PROXY_PORT  8080
 #define TOX_DEFAULT_TCP_PORT    0
 #define TOX_DEFAULT_START_PORT  33445


### PR DESCRIPTION
This is now defined by tox.h, so we no longer need our own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/56)
<!-- Reviewable:end -->
