### PR TITLE
Downgrade libsodium version.

### DIFF
--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -51,7 +51,10 @@ $(TOOLCHAIN)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libs
 # libsodium
 
 $(SRCDIR)/libsodium:
-	git clone --depth=1 --branch=1.0.16 https://github.com/jedisct1/libsodium $@
+#	TODO(iphydf): Upgrade to 1.0.17 once it's released. 14, 15, and 16 don't
+#	build on Android.
+#	git clone --depth=1 --branch=1.0.17 https://github.com/jedisct1/libsodium $@
+	git clone --depth=1 --branch=1.0.13 https://github.com/jedisct1/libsodium $@
 
 $(TOOLCHAIN)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)


### PR DESCRIPTION
Since the latest version doesn't build on Android. `master` does, so we can upgrade once 1.0.17 comes out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/57)
<!-- Reviewable:end -->
