### PR TITLE
Remove `--enable-minimal` from libsodium build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
     language: generic
     os: osx
     install: brew install sbt
-  #- env: GOAL=release TARGET=aarch64-linux-android
+  - env: GOAL=release TARGET=aarch64-linux-android
   - env: GOAL=release TARGET=arm-linux-androideabi
   - env: GOAL=release TARGET=i686-linux-android
   - env: GOAL=release TARGET=x86_64-linux-android

--- a/scripts/android.mk
+++ b/scripts/android.mk
@@ -16,7 +16,7 @@ export PATH		:= $(TOOLCHAIN)/bin:$(PATH)
 export TOX4J_PLATFORM	:= $(TARGET)
 
 protobuf_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared --with-protoc=$(PROTOC)
-libsodium_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared --enable-minimal
+libsodium_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
 opus_CONFIGURE		:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
 libvpx_CONFIGURE	:= --prefix=$(PREFIX) --sdk-path=$(NDK_HOME) --libc=$(SYSROOT) --target=$(VPX_ARCH) --disable-examples --disable-unit-tests --enable-pic
 toxcore_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c -DENABLE_STATIC=ON -DENABLE_SHARED=OFF


### PR DESCRIPTION
We need scrypt, which is not part of the minimal build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/58)
<!-- Reviewable:end -->
