### PR TITLE
Use `ByteSizeLong`, replacing the deprecated `ByteSize` call.

### DIFF
--- a/cpp/src/ToxAv/av.cpp
+++ b/cpp/src/ToxAv/av.cpp
@@ -32,10 +32,10 @@ TOX_METHOD (jbyteArray, Iterate,
 #else
         log_entry.print_result (toxav_iterate, av);
 #endif
-        if (events.ByteSize () == 0)
+        if (events.ByteSizeLong () == 0)
           return nullptr;
 
-        std::vector<char> buffer (events.ByteSize ());
+        std::vector<char> buffer (events.ByteSizeLong ());
         events.SerializeToArray (buffer.data (), buffer.size ());
         events.Clear ();
 

--- a/cpp/src/ToxAv/debug.cpp
+++ b/cpp/src/ToxAv/debug.cpp
@@ -34,5 +34,5 @@ print_arg<av::Events *> (protolog::Value &value, av::Events *const &events)
   if (events == nullptr)
     value.set_v_string ("<null>");
   else
-    value.set_v_string ("<av::Events[" + std::to_string (events->ByteSize ()) + "]>");
+    value.set_v_string ("<av::Events[" + std::to_string (events->ByteSizeLong ()) + "]>");
 }

--- a/cpp/src/ToxCore/connection.cpp
+++ b/cpp/src/ToxCore/connection.cpp
@@ -106,10 +106,10 @@ TOX_METHOD (jbyteArray, Iterate,
         LogEntry log_entry (instanceNumber, tox_iterate, tox);
 
         log_entry.print_result (tox_iterate, tox, &events);
-        if (events.ByteSize () == 0)
+        if (events.ByteSizeLong () == 0)
           return nullptr;
 
-        std::vector<char> buffer (events.ByteSize ());
+        std::vector<char> buffer (events.ByteSizeLong ());
         events.SerializeToArray (buffer.data (), buffer.size ());
         events.Clear ();
 

--- a/cpp/src/ToxCore/debug.cpp
+++ b/cpp/src/ToxCore/debug.cpp
@@ -47,7 +47,7 @@ print_arg<core::Events *> (protolog::Value &value, core::Events *const &events)
   if (events == nullptr)
     value.set_v_string ("<null>");
   else
-    value.set_v_string ("<core::Events[" + std::to_string (events->ByteSize ()) + "]>");
+    value.set_v_string ("<core::Events[" + std::to_string (events->ByteSizeLong ()) + "]>");
 }
 
 #define enum_case(ENUM)                               \

--- a/cpp/src/util/debug_log.cpp
+++ b/cpp/src/util/debug_log.cpp
@@ -114,7 +114,7 @@ JniLog::clear ()
         }
     }
 
-  std::vector<char> buffer (self->log.ByteSize ());
+  std::vector<char> buffer (self->log.ByteSizeLong ());
   self->log.SerializeToArray (buffer.data (), buffer.size ());
   self->log.Clear ();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/76)
<!-- Reviewable:end -->
