### PR TITLE
Fix JNI library loading for new JRE versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // General settings.
 organization  := "org.toktok"
 name          := "tox4j-c"
-version       := "0.2.1"
+version       := "0.2.2"
 scalaVersion  := "2.11.12"
 
 bintrayVcsUrl := Some("https://github.com/TokTok/jvm-toxcore-c")

--- a/src/main/java/im/tox/tox4j/impl/jni/ToxLoadJniLibrary.scala
+++ b/src/main/java/im/tox/tox4j/impl/jni/ToxLoadJniLibrary.scala
@@ -15,7 +15,7 @@ object ToxLoadJniLibrary {
 
   private val AlreadyLoaded = "Native Library (.+) already loaded in another classloader".r
   private val NotFoundDalvik = "Couldn't load .+ from loader .+ findLibrary returned null".r
-  private val NotFoundJvm = "no .+ in java.library.path".r
+  private val NotFoundJvm = "no .+ in java.library.path.*".r
 
   private def withTempFile(name: String)(block: File => Boolean): Boolean = {
     val (prefix, suffix) = name.splitAt(name.lastIndexOf("."))
@@ -113,7 +113,8 @@ object ToxLoadJniLibrary {
           case NotFoundDalvik() =>
             logger.error(s"Could not load native library '$name'; giving up.")
             false
-          case _ =>
+          case msg =>
+            logger.error(s"Unhandled UnsatisfiedLinkError: '$msg'.")
             false
         }) {
           logger.debug(s"Loading '$name' successful")


### PR DESCRIPTION
The error message now has the library path printed after it. To support
both old and new error message formats, we accept any text after the
message "no tox4j-c in java.library.path".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/78)
<!-- Reviewable:end -->
