### PR TITLE
Make audio playback tests available to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -143,6 +143,7 @@ scala_library(
         "src/test/java/im/tox/tox4j/ToxCoreTestBase.scala",
         "src/test/java/im/tox/tox4j/av/callbacks/audio/AudioGenerator.scala",
         "src/test/java/im/tox/tox4j/av/callbacks/audio/AudioGenerators.scala",
+        "src/test/java/im/tox/tox4j/av/callbacks/audio/AudioPlayback.scala",
         "src/test/java/im/tox/tox4j/av/callbacks/video/ArithmeticVideoGenerator.scala",
         "src/test/java/im/tox/tox4j/av/callbacks/video/RgbVideoGenerator.scala",
         "src/test/java/im/tox/tox4j/av/callbacks/video/TextImageGenerator.scala",
@@ -245,3 +246,74 @@ scala_library(
         "@com_google_guava_guava//jar",
     ],
 ) for src in glob(["src/test/java/im/tox/tox4j/impl/jni/codegen/Jni*.scala"])]
+
+scala_binary(
+    name = "AudioPlaybackShow",
+    testonly = True,
+    srcs = [
+        "src/tools/java/im/tox/tox4j/av/callbacks/audio/AudioPlaybackShow.scala",
+    ],
+    main_class = "im.tox.tox4j.av.callbacks.audio.AudioPlaybackShow",
+    resources = glob([
+        "src/test/resources/**/*",
+    ]),
+    deps = [
+        ":jvm-toxcore-c",
+        ":test_lib",
+        "//jvm-toxcore-api",
+    ],
+)
+
+scala_test(
+    name = "AudioReceiveFrameCallbackShow",
+    size = "small",
+    srcs = ["src/tools/java/im/tox/tox4j/av/callbacks/audio/AudioReceiveFrameCallbackShow.scala"],
+    data = [":native"],
+    jvm_flags = ["-Djava.library.path=jvm-toxcore-c"],
+    resources = glob([
+        "src/test/resources/**/*",
+    ]),
+    tags = ["manual"],
+    deps = [
+        ":jvm-toxcore-c",
+        ":test_lib",
+        "//jvm-toxcore-api",
+        "//third_party/scala:com_typesafe_scala_logging_scala_logging",
+        "@io_bazel_rules_scala//scala/scalatest",
+        "@log4j_log4j//jar",
+        "@org_jetbrains_annotations//jar",
+        "@org_slf4j_slf4j_api//jar",
+        "@org_slf4j_slf4j_log4j12//jar",
+    ],
+)
+
+scala_test(
+    name = "VideoReceiveFrameCallbackShow",
+    size = "small",
+    srcs = [
+        "src/tools/java/im/tox/tox4j/av/callbacks/video/ConsoleVideoDisplay.scala",
+        "src/tools/java/im/tox/tox4j/av/callbacks/video/GuiVideoDisplay.scala",
+        "src/tools/java/im/tox/tox4j/av/callbacks/video/RgbVideoDisplay.scala",
+        "src/tools/java/im/tox/tox4j/av/callbacks/video/VideoDisplay.scala",
+        "src/tools/java/im/tox/tox4j/av/callbacks/video/VideoReceiveFrameCallbackShow.scala",
+    ],
+    data = [":native"],
+    jvm_flags = ["-Djava.library.path=jvm-toxcore-c"],
+    resources = glob([
+        "src/test/resources/**/*",
+    ]),
+    tags = ["manual"],
+    deps = [
+        ":jvm-toxcore-c",
+        ":test_lib",
+        "//jvm-toxcore-api",
+        "//third_party/scala:com_chuusai_shapeless",
+        "//third_party/scala:com_typesafe_scala_logging_scala_logging",
+        "@io_bazel_rules_scala//scala/scalatest",
+        "@log4j_log4j//jar",
+        "@org_jetbrains_annotations//jar",
+        "@org_scala_lang_modules_scala_swing//jar",
+        "@org_slf4j_slf4j_api//jar",
+        "@org_slf4j_slf4j_log4j12//jar",
+    ],
+)

--- a/src/tools/java/im/tox/tox4j/av/callbacks/audio/AudioPlaybackShow.scala
+++ b/src/tools/java/im/tox/tox4j/av/callbacks/audio/AudioPlaybackShow.scala
@@ -1,11 +1,9 @@
 package im.tox.tox4j.av.callbacks.audio
 
 import im.tox.tox4j.av.data.{ AudioLength, SampleCount, SamplingRate }
-import jline.TerminalFactory
-import org.scalatest.FunSuite
 
 @SuppressWarnings(Array("org.wartremover.warts.While"))
-final class AudioPlaybackShow extends FunSuite {
+object AudioPlaybackShow {
 
   private val audio = AudioGenerators.default
 
@@ -14,8 +12,8 @@ final class AudioPlaybackShow extends FunSuite {
   private val frameSize = SampleCount(audioLength, samplingRate)
   private val playback = new AudioPlayback(samplingRate)
 
-  test("main") {
-    val terminalWidth = TerminalFactory.get.getWidth
+  def main(args: Array[String]) {
+    val terminalWidth = 190
 
     System.out.print("\u001b[2J")
 

--- a/src/tools/java/im/tox/tox4j/av/callbacks/video/GuiVideoDisplay.scala
+++ b/src/tools/java/im/tox/tox4j/av/callbacks/video/GuiVideoDisplay.scala
@@ -5,7 +5,7 @@ import java.awt.image.{ BufferedImage, DataBufferByte }
 import java.io.File
 import javax.imageio.ImageIO
 import javax.swing.border.EtchedBorder
-import javax.swing.{ BorderFactory, ImageIcon }
+import javax.swing.{ BorderFactory, ImageIcon, JDialog }
 
 import com.typesafe.scalalogging.Logger
 import im.tox.tox4j.av.callbacks.video.GuiVideoDisplay.{ UI, newImage }
@@ -69,7 +69,7 @@ object GuiVideoDisplay {
           BufferedImage.TYPE_INT_RGB
         )
 
-        dialog.self.paint(image.getGraphics)
+        dialog.self.asInstanceOf[JDialog].paint(image.getGraphics)
 
         ImageIO.write(image, "jpg", new File(capturePath, f"$frameNumber%03d.jpg"))
       }


### PR DESCRIPTION
We can use these to validate that audio calls on tox at least work
on localhost connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/82)
<!-- Reviewable:end -->
