### PR TITLE
Add missing dependency on annotations.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -144,6 +144,7 @@ scala_library(
         "//jvm-toxcore-api",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_jetbrains_annotations",
     ],
 )
 
@@ -265,6 +266,7 @@ scala_library(
         ":jvm-toxcore-c",
         "//jvm-toxcore-api",
         "@maven//:com_google_guava_guava",
+        "@maven//:org_jetbrains_annotations",
     ],
 ) for src in glob(["src/test/java/im/tox/tox4j/impl/jni/codegen/Jni*.scala"])]
 


### PR DESCRIPTION
The latest rules_scala is stricter in this and requires all dependencies
to be listed. Transitive dependencies no longer work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/91)
<!-- Reviewable:end -->
