### PR TITLE
chore: Use toktok-stack 0.0.23 for cirrus builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.19
+    image: toxchat/toktok-stack:0.0.23-third_party
     cpu: 2
     memory: 6G
   configure_script:
@@ -11,4 +11,4 @@ cirrus-ci_task:
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --config=release
         //jvm-toxcore-c/..."
-    - $TEST || $TEST || $TEST || $TEST
+    - cd /src/workspace && $TEST || $TEST || $TEST || $TEST


### PR DESCRIPTION
This version has pre-built third party binaries, speeding up the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/95)
<!-- Reviewable:end -->
