### PR TITLE
chore: Only require jni.h to be found when searching for the JNI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.23-third_party
+    image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
     memory: 6G
   configure_script:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -40,8 +40,8 @@ find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 
 find_package(JNI)
-if(JNI_FOUND)
-  include_directories(${JNI_INCLUDE_DIRS})
+if(JAVA_INCLUDE_PATH)
+  include_directories(${JAVA_INCLUDE_PATH})
 endif()
 
 include_directories("src")


### PR DESCRIPTION
Before this patch, we would only add the jni.h include path if both JNI
and AWT were found as FindJNI.cmake only sets JNI_FOUND if both JNI and
AWT were found, requiring you to install openjdk-11-jdk instead of
openjdk-11-jdk-headless for the build to succeed.

After this patch both the headless and the full jdk is fine.

See: https://cmake.org/cmake/help/v3.22/module/FindJNI.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/96)
<!-- Reviewable:end -->
