### PR TITLE
chore: Don't try to resolve now-sunset bintray repositories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ bintrayVcsUrl := Some("https://github.com/TokTok/jvm-toxcore-c")
 
 // Snapshot and linter repository.
 resolvers += Resolver.sonatypeRepo("snapshots")
-resolvers += Resolver.bintrayRepo("toktok", "maven")
 
 // Build dependencies.
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 // Common tox4j build rules.
-resolvers += Resolver.bintrayIvyRepo("toktok", "sbt-plugins")
 addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.6")
 
 // Compiler version for additional plugins in this project.


### PR DESCRIPTION
Building against a local repository still works fine, but the build
takes a lot longer as it has to time out trying to resolve bintray
repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-c/97)
<!-- Reviewable:end -->
