### PR TITLE
test: Remove tests that no longer work with better error reporting.

### DIFF
--- a/src/test/java/im/tox/tox4j/ToxTest.scala
+++ b/src/test/java/im/tox/tox4j/ToxTest.scala
@@ -56,6 +56,11 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
     withToxUnit(_.close())
   }
 
+  /*
+   * Can't easily test this anymore, because bootstrap now actually reports
+   * success/failure immediately.
+   */
+  /*
   test("BootstrapBorderlinePort1") {
     withToxUnit { tox =>
       tox.bootstrap(
@@ -75,6 +80,7 @@ final class ToxCoreTest extends FunSuite with ToxTestMixin {
       )
     }
   }
+  */
 
   test("IterationInterval") {
     withToxUnit { tox =>


### PR DESCRIPTION
Toxcore now reports failure to bootstrap immediately.

See https://github.com/TokTok/c-toxcore/pull/2104

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/jvm-toxcore-c/105)
<!-- Reviewable:end -->
