### PR TITLE
chore: Fix build scripts breaking if parens exist in $PATH

### DIFF
--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -87,7 +87,7 @@ $(SRCDIR)/libvpx:
 
 $(PREFIX)/libvpx.stamp: $(SRCDIR)/libvpx $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)
-	echo $(PATH)
+	echo "$(PATH)"
 	mkdir -p $(BUILDDIR)/$(notdir $<)
 	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
 	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install


### PR DESCRIPTION
`/bin/sh: 1: Syntax error: "(" unexpected`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/jvm-toxcore-c/106)
<!-- Reviewable:end -->
