### PR TITLE
perf: Move to protobuf-lite.

### DIFF
--- a/docker/jvm.Dockerfile
+++ b/docker/jvm.Dockerfile
@@ -17,9 +17,27 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work/jvm-toxcore-c
+# Rarely changing external dependencies.
 COPY scripts/ /work/jvm-toxcore-c/scripts/
 RUN scripts/build-host "$PWD/_install/host/protobuf.stamp" "-j$(nproc)"
 RUN scripts/build-host "$PWD/_install/host/toxcore.stamp" "-j$(nproc)"
+
+# Native code, changes less frequently.
 COPY lib/src/main/cpp/ /work/jvm-toxcore-c/lib/src/main/cpp/
 COPY lib/src/main/proto/ /work/jvm-toxcore-c/lib/src/main/proto/
-RUN scripts/build-host "$PWD/_install/host/tox4j.stamp" "-j$(nproc)"
+RUN touch "$PWD/_install/host/.stamp" \
+ && touch "$PWD/_install/host/libsodium.stamp" \
+ && touch "$PWD/_install/host/libvpx.stamp" \
+ && touch "$PWD/_install/host/opus.stamp" \
+ && touch "$PWD/_install/host/protobuf.stamp" \
+ && touch "$PWD/_install/host/toxcore.stamp" \
+ && scripts/build-host "$PWD/_install/host/tox4j.stamp" "-j$(nproc)"
+RUN ["ls", "-lh", "/work/jvm-toxcore-c/_install/host/lib/libtox4j-c.so"]
+
+# Java/Kotlin code changes a lot.
+COPY gradlew gradle.properties settings.gradle.kts /work/jvm-toxcore-c/
+COPY gradle /work/jvm-toxcore-c/gradle/
+COPY lib/ /work/jvm-toxcore-c/lib/
+ENV LD_LIBRARY_PATH=/work/jvm-toxcore-c/_install/host/lib
+ENV PATH=/work/jvm-toxcore-c/_install/host/bin:$PATH
+RUN ./gradlew build

--- a/lib/src/main/cpp/CMakeLists.txt
+++ b/lib/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(tox4j-c)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH true)
@@ -11,42 +11,9 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 
-pkg_search_module(LIBTOXCORE libtoxcore)
-if(LIBTOXCORE_FOUND)
-  pkg_search_module(LIBTOXAV REQUIRED libtoxav)
-  link_directories(${LIBTOXCORE_LIBRARY_DIRS})
-  include_directories(${LIBTOXCORE_INCLUDE_DIRS})
-  foreach(flag ${LIBTOXCORE_CFLAGS_OTHER})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  endforeach()
-
-  link_directories(${LIBTOXAV_LIBRARY_DIRS})
-  include_directories(${LIBTOXAV_INCLUDE_DIRS})
-  foreach(flag ${LIBTOXAV_CFLAGS_OTHER})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  endforeach()
-else()
-  pkg_search_module(TOXCORE REQUIRED toxcore)
-  link_directories(${TOXCORE_LIBRARY_DIRS})
-  include_directories(${TOXCORE_INCLUDE_DIRS})
-  foreach(flag ${TOXCORE_CFLAGS_OTHER})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  endforeach()
-endif()
-
-find_package(Protobuf REQUIRED)
-include_directories(${PROTOBUF_INCLUDE_DIRS})
-
+pkg_search_module(TOXCORE REQUIRED toxcore)
+find_package(protobuf CONFIG REQUIRED)
 find_package(JNI)
-if(JAVA_INCLUDE_PATH)
-  include_directories(${JAVA_INCLUDE_PATH})
-endif()
-if(JAVA_INCLUDE_PATH2)
-  include_directories(${JAVA_INCLUDE_PATH2})
-endif()
-
-include_directories(${CMAKE_SOURCE_DIR})
-include_directories(${CMAKE_BINARY_DIR})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
@@ -96,14 +63,12 @@ endif()
 # Build
 #
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ToxAv/Av.proto
-                      ToxCore/Core.proto util/ProtoLog.proto)
-
 add_library(
   ${PROJECT_NAME} SHARED
   ${ANDROID_CPU_FEATURES}
-  ${PROTO_SRCS}
-  ${PROTO_HDRS}
+  ToxAv/Av.proto
+  ToxCore/Core.proto
+  util/ProtoLog.proto
   ToxAv/generated/enums.cpp
   ToxAv/generated/errors.cpp
   ToxAv/generated/impls.h
@@ -175,14 +140,27 @@ if(ANDROID_CPU_FEATURES)
   target_compile_definitions(${PROJECT_NAME} PRIVATE -Dtypeof=__typeof__)
 endif()
 
-target_link_libraries(${PROJECT_NAME} ${PROTOBUF_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf-lite)
 
-if(LIBTOXCORE_FOUND)
-  target_link_libraries(${PROJECT_NAME} ${LIBTOXAV_STATIC_LIBRARIES}
-                        ${LIBTOXCORE_STATIC_LIBRARIES})
-else()
-  target_link_libraries(${PROJECT_NAME} ${TOXCORE_STATIC_LIBRARIES})
+if(JAVA_INCLUDE_PATH)
+  target_include_directories(${PROJECT_NAME} PUBLIC ${JAVA_INCLUDE_PATH})
 endif()
+if(JAVA_INCLUDE_PATH2)
+  target_include_directories(${PROJECT_NAME} PUBLIC ${JAVA_INCLUDE_PATH2})
+endif()
+
+target_link_directories(${PROJECT_NAME} PUBLIC ${TOXCORE_LIBRARY_DIRS})
+target_link_libraries(${PROJECT_NAME} ${TOXCORE_STATIC_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${TOXCORE_INCLUDE_DIRS})
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR}/ToxAv)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR}/ToxCore)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR}/util)
+
+protobuf_generate(TARGET ${PROJECT_NAME})
 
 # Windows and OSX don't have this linker functionality.
 if(NOT WIN32 AND NOT APPLE)

--- a/lib/src/main/proto/Av.proto
+++ b/lib/src/main/proto/Av.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package im.tox.tox4j.av.proto;
 
 option java_multiple_files = true;
+option optimize_for = LITE_RUNTIME;
 
 message Call {
   int32         friend_number     = 1;

--- a/lib/src/main/proto/Core.proto
+++ b/lib/src/main/proto/Core.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package im.tox.tox4j.core.proto;
 
 option java_multiple_files = true;
+option optimize_for = LITE_RUNTIME;
 
 message Connection {
   enum Type {

--- a/lib/src/main/proto/ProtoLog.proto
+++ b/lib/src/main/proto/ProtoLog.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package im.tox.tox4j.impl.jni.proto;
 
+option java_multiple_files = true;
+option optimize_for = LITE_RUNTIME;
 
 // struct timeval from <sys/time.h> representing a point in time.
 message Timestamp {

--- a/scripts/build-host
+++ b/scripts/build-host
@@ -39,7 +39,7 @@ cpp/src/ToxCrypto/generated/im_tox_tox4j_impl_jni_ToxCryptoJni.h: build
 %.run: ; $*
 regenerate: $(foreach i,$(wildcard bin/Jni*),$i.run) $(wildcard cpp/src/*/generated/*.h)
 
-protobuf_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
+protobuf_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_DISABLE_RTTI=ON -Dprotobuf_BUILD_SHARED_LIBS=OFF
 libsodium_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
 opus_CONFIGURE		:= --prefix=$(PREFIX) --disable-shared
 libvpx_CONFIGURE	:= --prefix=$(PREFIX) --disable-examples --disable-unit-tests --enable-pic

--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -1,6 +1,8 @@
 PRE_RULE = (echo "=== Building $@ ==="; ls -ld $@; true) && ls -ld $+
 POST_RULE = ls -ld $@
 
+GIT_CLONE = git clone --depth=1 --recurse-submodules --shallow-submodules
+
 $(BUILDDIR)/tox4j/Makefile: $(CURDIR)/lib/src/main/cpp/CMakeLists.txt $(TOOLCHAIN_FILE) $(foreach i,protobuf toxcore,$(PREFIX)/$i.stamp)
 	@$(PRE_RULE)
 	mkdir -p $(@D)
@@ -17,14 +19,13 @@ $(PREFIX)/tox4j.stamp: $(BUILDDIR)/tox4j/Makefile
 # protobuf
 
 $(SRCDIR)/protobuf:
-	git clone --depth=1 --branch=v3.11.1 https://github.com/google/protobuf $@
+	$(GIT_CLONE) --branch=v3.24.4 https://github.com/protocolbuffers/protobuf $@
 
 $(PREFIX)/protobuf.stamp: $(SRCDIR)/protobuf $(TOOLCHAIN_FILE) $(PROTOC)
 	@$(PRE_RULE)
-	cd $< && autoreconf -fi
 	mkdir -p $(BUILDDIR)/$(notdir $<)
-	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
-	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install V=0
+	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE)
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
 	mkdir -p $(@D) && touch $@
 	@$(POST_RULE)
 
@@ -35,7 +36,7 @@ $(SRCDIR)/toxcore:
 	if [ -e ../c-toxcore ]; then								\
 	  ln -s $(realpath ../c-toxcore) $@;							\
 	else											\
-	  git clone --depth=1 --recurse-submodules https://github.com/TokTok/c-toxcore $@;	\
+	  $(GIT_CLONE) https://github.com/TokTok/c-toxcore $@;	\
 	fi
 
 $(PREFIX)/toxcore.stamp: $(foreach f,$(shell cd $(SRCDIR)/toxcore && git ls-files),$(SRCDIR)/toxcore/$f)
@@ -51,7 +52,7 @@ $(PREFIX)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodi
 # libsodium
 
 $(SRCDIR)/libsodium:
-	git clone --depth=1 --branch=1.0.18 https://github.com/jedisct1/libsodium $@
+	$(GIT_CLONE) --branch=1.0.18 https://github.com/jedisct1/libsodium $@
 
 $(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)
@@ -66,7 +67,7 @@ $(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 # opus
 
 $(SRCDIR)/opus:
-	git clone --depth=1 https://github.com/xiph/opus $@
+	$(GIT_CLONE) https://github.com/xiph/opus $@
 
 $(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)
@@ -81,7 +82,7 @@ $(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)
 # libvpx
 
 $(SRCDIR)/libvpx:
-	git clone --depth=1 --branch=v1.6.0 https://github.com/webmproject/libvpx $@
+	$(GIT_CLONE) --branch=v1.6.0 https://github.com/webmproject/libvpx $@
 	cd $@ && patch -p1 < $(CURDIR)/scripts/patches/libvpx.patch
 
 $(PREFIX)/libvpx.stamp: $(SRCDIR)/libvpx $(TOOLCHAIN_FILE)


### PR DESCRIPTION
7.3M -> 4.8M for the JNI library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/jvm-toxcore-c/111)
<!-- Reviewable:end -->
