### PR TITLE
chore: Support publishing the kmp jvm artifacts to maven repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ hsdis-*.*
 
 # Ignore Gradle build output directory
 build
+
+# Local Gradle configuration
+local.properties

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -4,7 +4,13 @@ plugins {
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
+
+    // https://docs.gradle.org/current/userguide/publishing_maven.html
+    `maven-publish`
 }
+
+group = "org.toktok"
+version = "0.3.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.
@@ -30,6 +36,15 @@ testing {
         val test by getting(JvmTestSuite::class) {
             // Use Kotlin Test test framework
             useKotlinTest("1.9.22")
+        }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            artifactId = "tox4j-c"
+            from(components["java"])
         }
     }
 }


### PR DESCRIPTION
This is enough to be able to publish tox4j w/ `gradlew publishToMavenLocal`, and depend on `org.toktok:tox4j-c:0.3.0` from a different project and get errors like
```
aTox/domain/src/main/kotlin/tox/ToxAvEventListener.kt:74:5 'callState' overrides nothing. Potential signatures for overriding:
fun callState(friendNumber: ToxFriendNumber, callState: Set<ToxavFriendCallState>, state: Unit): Unit
aTox/domain/src/main/kotlin/tox/ToxUtil.kt:33:5 Argument type mismatch: actual type is 'kotlin.Int', but 'kotlin.UShort' was expected.
aTox/domain/src/main/kotlin/tox/ToxWrapper.kt:116:13 Argument type mismatch: actual type is 'kotlin.Pair<A, B>', but 'kotlin.Pair<ltd.evilcorp.domain.tox.PublicKey, kotlin.Int>' was expected.
```

Note that this does nothing with the .so-dependencies, so depending on jvm-toxcore-c like this right now will require the user to also place libtox4j-c.so in the jniLibs-structure themselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/jvm-toxcore-c/130)
<!-- Reviewable:end -->
